### PR TITLE
Add validation for length of comments

### DIFF
--- a/src/components/CommentForm.js
+++ b/src/components/CommentForm.js
@@ -7,7 +7,7 @@ import TextField from '@material-ui/core/TextField'
 export default function CommentForm({ projectId, mutateComment }) {
   const classes = useStyles()
   const [body, setBody] = useState('')
-  const [errorMessage, setErrorMessage] = useState(null)
+  const [errorMessages, setErrorMessages] = useState([])
 
   const handleSubmit = async event => {
     event.preventDefault()
@@ -16,9 +16,9 @@ export default function CommentForm({ projectId, mutateComment }) {
       await request.post(`/projects/${projectId}/comments`, { body })
       mutateComment()
       setBody('')
-      setErrorMessage(null)
+      setErrorMessages([])
     } catch (error) {
-      setErrorMessage(error.response.data)
+      setErrorMessages(error.response.data)
     }
   }
 
@@ -36,8 +36,10 @@ export default function CommentForm({ projectId, mutateComment }) {
         autoFocus
         value={body}
         onChange={event => setBody(event.target.value)}
-        error={errorMessage !== null}
-        helperText={errorMessage}
+        error={errorMessages.length > 0}
+        helperText={errorMessages.map(errorMessage => (
+          <div>{errorMessage}</div>
+        ))}
       />
 
       <Button type='submit' fullWidth variant='contained' color='primary' className={classes.submit}>

--- a/src/components/CommentForm.js
+++ b/src/components/CommentForm.js
@@ -7,6 +7,7 @@ import TextField from '@material-ui/core/TextField'
 export default function CommentForm({ projectId, mutateComment }) {
   const classes = useStyles()
   const [body, setBody] = useState('')
+  const [errorMessage, setErrorMessage] = useState(null)
 
   const handleSubmit = async event => {
     event.preventDefault()
@@ -15,8 +16,9 @@ export default function CommentForm({ projectId, mutateComment }) {
       await request.post(`/projects/${projectId}/comments`, { body })
       mutateComment()
       setBody('')
+      setErrorMessage(null)
     } catch (error) {
-      console.log(error)
+      setErrorMessage(error.response.data)
     }
   }
 
@@ -34,6 +36,8 @@ export default function CommentForm({ projectId, mutateComment }) {
         autoFocus
         value={body}
         onChange={event => setBody(event.target.value)}
+        error={errorMessage !== null}
+        helperText={errorMessage}
       />
 
       <Button type='submit' fullWidth variant='contained' color='primary' className={classes.submit}>


### PR DESCRIPTION
## Objective
コメントの長さが100文字いないじゃない場合にエラーを表示するようにしました。
<img width="700" alt="Screen Shot 2021-06-16 at 11 13 17" src="https://user-images.githubusercontent.com/81562992/122147796-8bbf8c00-ce94-11eb-9170-3293779cb366.png">
<!-- Describe the background and target of this PR -->

## Related Links
https://github.com/benrickken/crowdfunding-api/pull/38
<!-- Add related links -->
