### PR TITLE
Show notification menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.11.4",
+    "@material-ui/icons": "^4.11.2",
     "axios": "^0.21.1",
     "date-fns": "^2.21.3",
     "firebase": "^8.3.2",

--- a/src/components/CommentForm.js
+++ b/src/components/CommentForm.js
@@ -37,9 +37,7 @@ export default function CommentForm({ projectId, mutateComment }) {
         value={body}
         onChange={event => setBody(event.target.value)}
         error={errorMessages.length > 0}
-        helperText={errorMessages.map(errorMessage => (
-          <div>{errorMessage}</div>
-        ))}
+        helperText={errorMessages.length > 0 && errorMessages.map(errorMessage => <div>{errorMessage}</div>)}
       />
 
       <Button type='submit' fullWidth variant='contained' color='primary' className={classes.submit}>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,24 +1,14 @@
 import Link from 'next/link'
-import { useState, useRef } from 'react'
-import request from '../utils/request'
-import useSWR from 'swr'
 import { makeStyles } from '@material-ui/core/styles'
 import AppBar from '@material-ui/core/AppBar'
 import Toolbar from '@material-ui/core/Toolbar'
 import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
-import IconButton from '@material-ui/core/IconButton'
-import Badge from '@material-ui/core/Badge'
-import Menu from '@material-ui/core/Menu'
-import MenuItem from '@material-ui/core/MenuItem'
-import NotificationsIcon from '@material-ui/icons/Notifications'
 import firebase from '../utils/Firebase'
+import HeaderNotificationMenu from './HeaderNotificationMenu'
 
 export default function Header({ user, loading }) {
   const classes = useStyles()
-  const [isNotificationOpen, setIsNotificationOpen] = useState(false)
-  const notificationAnchorRef = useRef(null)
-  const { data: notifications } = useSWR('/me/notifications', notificationsFetcher)
 
   const logOut = async () => {
     try {
@@ -26,14 +16,6 @@ export default function Header({ user, loading }) {
     } catch (error) {
       console.log(error)
     }
-  }
-
-  const handleNotificationOpen = () => {
-    setIsNotificationOpen(true)
-  }
-
-  const handleNotificationClose = () => {
-    setIsNotificationOpen(false)
   }
 
   return (
@@ -50,36 +32,7 @@ export default function Header({ user, loading }) {
               <Link href='/projects/new'>
                 <Button color='inherit'>はじめる</Button>
               </Link>
-              <IconButton color='inherit' onClick={handleNotificationOpen} ref={notificationAnchorRef}>
-                <Badge badgeContent={notifications && notifications.length} color='secondary'>
-                  <NotificationsIcon />
-                </Badge>
-              </IconButton>
-              <Menu
-                anchorEl={notificationAnchorRef.current}
-                keepMounted
-                getContentAnchorEl={null}
-                anchorOrigin={{
-                  vertical: 'bottom',
-                  horizontal: 'left',
-                }}
-                open={isNotificationOpen}
-                onClose={handleNotificationClose}
-              >
-                {notifications && notifications.length > 0 ? (
-                  notifications.map(notification => (
-                    <MenuItem key={notification.id}>
-                      {notification.link !== null ? (
-                        <Link href={notification.link}>{notification.body}</Link>
-                      ) : (
-                        notification.body
-                      )}
-                    </MenuItem>
-                  ))
-                ) : (
-                  <MenuItem>通知はありません</MenuItem>
-                )}
-              </Menu>
+              <HeaderNotificationMenu />
               <Link href='/profile'>
                 <Button color='inherit'>{user.name}</Button>
               </Link>
@@ -101,8 +54,6 @@ export default function Header({ user, loading }) {
     </AppBar>
   )
 }
-
-const notificationsFetcher = url => request.get(url).then(res => res.data.notifications)
 
 const useStyles = makeStyles(theme => ({
   root: {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -32,7 +32,7 @@ export default function Header({ user, loading }) {
               <Link href='/projects/new'>
                 <Button color='inherit'>はじめる</Button>
               </Link>
-              <HeaderNotificationMenu />
+              <HeaderNotificationMenu unreadNotificationsCount={user.unreadNotificationsCount} />
               <Link href='/profile'>
                 <Button color='inherit'>{user.name}</Button>
               </Link>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,13 +1,24 @@
 import Link from 'next/link'
+import { useState, useRef } from 'react'
+import request from '../utils/request'
+import useSWR from 'swr'
 import { makeStyles } from '@material-ui/core/styles'
 import AppBar from '@material-ui/core/AppBar'
 import Toolbar from '@material-ui/core/Toolbar'
 import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
+import IconButton from '@material-ui/core/IconButton'
+import Badge from '@material-ui/core/Badge'
+import Menu from '@material-ui/core/Menu'
+import MenuItem from '@material-ui/core/MenuItem'
+import NotificationsIcon from '@material-ui/icons/Notifications'
 import firebase from '../utils/Firebase'
 
 export default function Header({ user, loading }) {
   const classes = useStyles()
+  const [isNotificationOpen, setIsNotificationOpen] = useState(false)
+  const notificationAnchorRef = useRef(null)
+  const { data: notifications } = useSWR('/me/notifications', notificationsFetcher)
 
   const logOut = async () => {
     try {
@@ -15,6 +26,14 @@ export default function Header({ user, loading }) {
     } catch (error) {
       console.log(error)
     }
+  }
+
+  const handleNotificationOpen = () => {
+    setIsNotificationOpen(true)
+  }
+
+  const handleNotificationClose = () => {
+    setIsNotificationOpen(false)
   }
 
   return (
@@ -31,6 +50,28 @@ export default function Header({ user, loading }) {
               <Link href='/projects/new'>
                 <Button color='inherit'>はじめる</Button>
               </Link>
+              <IconButton color='inherit' onClick={handleNotificationOpen} ref={notificationAnchorRef}>
+                <Badge badgeContent={notifications.length} color='secondary'>
+                  <NotificationsIcon />
+                </Badge>
+              </IconButton>
+              <Menu
+                anchorEl={notificationAnchorRef.current}
+                keepMounted
+                getContentAnchorEl={null}
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'left',
+                }}
+                open={isNotificationOpen}
+                onClose={handleNotificationClose}
+              >
+                {notifications.length > 0 ? (
+                  notifications.map(notification => <MenuItem key={notification.id}>{notification.body}</MenuItem>)
+                ) : (
+                  <MenuItem>通知はありません</MenuItem>
+                )}
+              </Menu>
               <Link href='/profile'>
                 <Button color='inherit'>{user.name}</Button>
               </Link>
@@ -52,6 +93,8 @@ export default function Header({ user, loading }) {
     </AppBar>
   )
 }
+
+const notificationsFetcher = url => request.get(url).then(res => res.data.notifications)
 
 const useStyles = makeStyles(theme => ({
   root: {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -51,7 +51,7 @@ export default function Header({ user, loading }) {
                 <Button color='inherit'>はじめる</Button>
               </Link>
               <IconButton color='inherit' onClick={handleNotificationOpen} ref={notificationAnchorRef}>
-                <Badge badgeContent={notifications.length} color='secondary'>
+                <Badge badgeContent={notifications && notifications.length} color='secondary'>
                   <NotificationsIcon />
                 </Badge>
               </IconButton>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -66,8 +66,16 @@ export default function Header({ user, loading }) {
                 open={isNotificationOpen}
                 onClose={handleNotificationClose}
               >
-                {notifications.length > 0 ? (
-                  notifications.map(notification => <MenuItem key={notification.id}>{notification.body}</MenuItem>)
+                {notifications && notifications.length > 0 ? (
+                  notifications.map(notification => (
+                    <MenuItem key={notification.id}>
+                      {notification.link !== null ? (
+                        <Link href={notification.link}>{notification.body}</Link>
+                      ) : (
+                        notification.body
+                      )}
+                    </MenuItem>
+                  ))
                 ) : (
                   <MenuItem>通知はありません</MenuItem>
                 )}

--- a/src/components/HeaderNotificationMenu.js
+++ b/src/components/HeaderNotificationMenu.js
@@ -1,0 +1,60 @@
+import Link from 'next/link'
+import { useState, useRef } from 'react'
+import request from '../utils/request'
+import useSWR from 'swr'
+import IconButton from '@material-ui/core/IconButton'
+import Badge from '@material-ui/core/Badge'
+import Menu from '@material-ui/core/Menu'
+import MenuItem from '@material-ui/core/MenuItem'
+import NotificationsIcon from '@material-ui/icons/Notifications'
+
+export default function HeaderNotificationMenu() {
+  const [isNotificationOpen, setIsNotificationOpen] = useState(false)
+  const notificationAnchorRef = useRef(null)
+  const { data: notifications } = useSWR('/me/notifications', notificationsFetcher)
+
+  const handleNotificationOpen = () => {
+    setIsNotificationOpen(true)
+  }
+
+  const handleNotificationClose = () => {
+    setIsNotificationOpen(false)
+  }
+
+  return (
+    <>
+      <IconButton color='inherit' onClick={handleNotificationOpen} ref={notificationAnchorRef}>
+        <Badge badgeContent={notifications && notifications.length} color='secondary'>
+          <NotificationsIcon />
+        </Badge>
+      </IconButton>
+      <Menu
+        anchorEl={notificationAnchorRef.current}
+        keepMounted
+        getContentAnchorEl={null}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        open={isNotificationOpen}
+        onClose={handleNotificationClose}
+      >
+        {notifications && notifications.length > 0 ? (
+          notifications.map(notification => (
+            <MenuItem key={notification.id}>
+              {notification.link !== null ? (
+                <Link href={notification.link}>{notification.body}</Link>
+              ) : (
+                notification.body
+              )}
+            </MenuItem>
+          ))
+        ) : (
+          <MenuItem>通知はありません</MenuItem>
+        )}
+      </Menu>
+    </>
+  )
+}
+
+const notificationsFetcher = url => request.get(url).then(res => res.data.notifications)

--- a/src/components/HeaderNotificationMenu.js
+++ b/src/components/HeaderNotificationMenu.js
@@ -8,7 +8,7 @@ import Menu from '@material-ui/core/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
 import NotificationsIcon from '@material-ui/icons/Notifications'
 
-export default function HeaderNotificationMenu() {
+export default function HeaderNotificationMenu({ unreadNotificationsCount }) {
   const [isNotificationOpen, setIsNotificationOpen] = useState(false)
   const notificationAnchorRef = useRef(null)
   const { data: notifications } = useSWR('/me/notifications', notificationsFetcher)
@@ -24,7 +24,7 @@ export default function HeaderNotificationMenu() {
   return (
     <>
       <IconButton color='inherit' onClick={handleNotificationOpen} ref={notificationAnchorRef}>
-        <Badge badgeContent={notifications && notifications.length} color='secondary'>
+        <Badge badgeContent={unreadNotificationsCount} color='secondary'>
           <NotificationsIcon />
         </Badge>
       </IconButton>

--- a/src/components/HeaderNotificationMenu.js
+++ b/src/components/HeaderNotificationMenu.js
@@ -15,6 +15,7 @@ export default function HeaderNotificationMenu({ unreadNotificationsCount }) {
 
   const handleNotificationOpen = () => {
     setIsNotificationOpen(true)
+    request.patch('/me/read_notifications')
   }
 
   const handleNotificationClose = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,6 +330,13 @@
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.11.4":
   version "4.11.4"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"


### PR DESCRIPTION
## Objective
自分への通知を取得して表示できるようにしました。
<img width="461" alt="Screen Shot 2021-06-17 at 9 51 53" src="https://user-images.githubusercontent.com/81562992/122313706-aa378d00-cf51-11eb-9de1-d629974309cb.png">

## What was changed
* material-ui/iconsの追加
* HeaderNotificationMenuの作成
* 未読のnotificationの数を表示
* notification menuを開いたときに未読のnotificationをreadに変更するpatch requestの送信

## Related Links
https://github.com/benrickken/crowdfunding-api/pull/42
<!-- Add related links -->
